### PR TITLE
fix(pin): import seed side effects

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -855,7 +855,7 @@ pub async fn import_seed_words(
         }
         Err(e) => {
             error!(target: LOG_TARGET, "Error importing seed words by internal wallet: {e:?}");
-            e.to_string();
+            return Err(InvokeError::from_anyhow(e));
         }
     }
 

--- a/src-tauri/src/wallet_adapter.rs
+++ b/src-tauri/src/wallet_adapter.rs
@@ -402,10 +402,6 @@ impl ProcessAdapter for WalletAdapter {
             binary_version_path.clone(),
         )?;
 
-        println!("-------- START Wallet Binary with keys:");
-        println!("View Private Key: {}", self.view_private_key);
-        println!("Spend Key: {}", self.spend_key);
-
         let mut envs = std::collections::HashMap::new();
         envs.insert(
             "MINOTARI_WALLET_PASSWORD".to_string(),

--- a/src/components/wallet/seedwords/SeedWords.tsx
+++ b/src/components/wallet/seedwords/SeedWords.tsx
@@ -4,7 +4,7 @@ import { useCopyToClipboard } from '@app/hooks';
 import { IconButton } from '@app/components/elements/buttons/IconButton.tsx';
 import { CircularProgress } from '@app/components/elements/CircularProgress.tsx';
 import { IoCheckmarkOutline, IoCloseOutline, IoCopyOutline, IoPencil } from 'react-icons/io5';
-import { useCallback, useState, useTransition } from 'react';
+import { useCallback, useEffect, useState, useTransition } from 'react';
 import { Wrapper } from './styles.ts';
 import { CTASArea, InputArea, WalletSettingsGrid } from '@app/containers/floating/Settings/sections/wallet/styles.ts';
 import { Edit } from '@app/components/wallet/seedwords/components/Edit.tsx';
@@ -17,8 +17,11 @@ import { Button } from '@app/components/elements/buttons/Button.tsx';
 import { useTranslation } from 'react-i18next';
 import { Form } from '@app/components/wallet/seedwords/components/edit.styles.ts';
 import LoadingDots from '@app/components/elements/loaders/LoadingDots.tsx';
+import { useCountdown } from './utils.ts';
 
 // Controller component for edit/view seed words (both Tari & Monero)
+
+const SEED_WORDS_COUNTDOWN_DURATION = 30; // 30 seconds
 
 interface SeedWordsProps {
     isMonero?: boolean;
@@ -33,16 +36,47 @@ export default function SeedWords({ isMonero = false }: SeedWordsProps) {
 
     const { t } = useTranslation('settings', { useSuspense: false });
     const { copyToClipboard, isCopied } = useCopyToClipboard();
-    const { seedWords, getSeedWords, seedWordsFetched, seedWordsFetching } = useGetSeedWords({
+    const { seedWords, getSeedWords, setSeedWords, seedWordsFetched, seedWordsFetching } = useGetSeedWords({
         fetchMoneroSeeds: isMonero,
     });
     const methods = useForm({ defaultValues: { seedWords: seedWords?.join(' ').trim() } });
     const { isValid } = methods.formState;
 
+    // Countdown hook for auto-hiding seed words
+    const {
+        countdown,
+        start: startCountdown,
+        stop: stopCountdown,
+    } = useCountdown({
+        duration: SEED_WORDS_COUNTDOWN_DURATION,
+        onComplete: () => {
+            setShowConfirm(false);
+            setIsEditView(false);
+            setIsVisible(false);
+            setSeedWords([]);
+        },
+    });
+    useEffect(() => {
+        if (isWalletImporting || isEditView) {
+            setSeedWords([]);
+            setIsVisible(false);
+            stopCountdown();
+        }
+    }, [isEditView, isWalletImporting, setSeedWords, stopCountdown]);
+    // Start countdown when seed words become visible
+    useEffect(() => {
+        if (isVisible && seedWords?.length && seedWordsFetched) {
+            startCountdown();
+        } else {
+            stopCountdown();
+        }
+    }, [isVisible, seedWords, seedWordsFetched, startCountdown, stopCountdown]);
+
     const handleConfirmed = useCallback(async () => {
         if (!isValid || !newSeedWords) return;
 
-        await importSeedWords(newSeedWords).finally(() => setShowConfirm(false));
+        importSeedWords(newSeedWords);
+        setShowConfirm(false);
         setIsEditView(false);
     }, [isValid, newSeedWords]);
 
@@ -64,11 +98,13 @@ export default function SeedWords({ isMonero = false }: SeedWordsProps) {
                         setIsVisible(false);
                     });
             } else {
+                setSeedWords([]);
                 setIsVisible((c) => !c);
             }
         });
     }
     function onToggleEdit() {
+        methods.reset();
         setIsEditView((c) => !c);
     }
     function handleReset() {
@@ -92,7 +128,7 @@ export default function SeedWords({ isMonero = false }: SeedWordsProps) {
     const displayCTAs = (
         <>
             {!isMonero ? (
-                <IconButton size="small" onClick={onToggleEdit} type="button">
+                <IconButton size="small" disabled={isWalletImporting} onClick={onToggleEdit} type="button">
                     <IoPencil />
                 </IconButton>
             ) : null}

--- a/src/components/wallet/seedwords/SeedWords.tsx
+++ b/src/components/wallet/seedwords/SeedWords.tsx
@@ -43,11 +43,7 @@ export default function SeedWords({ isMonero = false }: SeedWordsProps) {
     const { isValid } = methods.formState;
 
     // Countdown hook for auto-hiding seed words
-    const {
-        countdown,
-        start: startCountdown,
-        stop: stopCountdown,
-    } = useCountdown({
+    const { start: startCountdown, stop: stopCountdown } = useCountdown({
         duration: SEED_WORDS_COUNTDOWN_DURATION,
         onComplete: () => {
             setShowConfirm(false);

--- a/src/components/wallet/seedwords/utils.ts
+++ b/src/components/wallet/seedwords/utils.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseCountdownOptions {
+    duration: number;
+    onComplete?: () => void;
+    autoStart?: boolean;
+}
+
+interface UseCountdownReturn {
+    countdown: number | null;
+    isActive: boolean;
+    start: () => void;
+    stop: () => void;
+    reset: () => void;
+}
+
+export function useCountdown({ duration, onComplete, autoStart = false }: UseCountdownOptions): UseCountdownReturn {
+    const [countdown, setCountdown] = useState<number | null>(autoStart ? duration : null);
+    const [isActive, setIsActive] = useState(autoStart);
+    const intervalRef = useRef<NodeJS.Timeout | null>(null);
+    const onCompleteRef = useRef(onComplete);
+
+    // Keep the onComplete callback ref up to date
+    useEffect(() => {
+        onCompleteRef.current = onComplete;
+    }, [onComplete]);
+
+    const start = useCallback(() => {
+        setCountdown(duration);
+        setIsActive(true);
+    }, [duration]);
+
+    const stop = useCallback(() => {
+        setIsActive(false);
+        setCountdown(null);
+        if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
+        }
+    }, []);
+
+    const reset = useCallback(() => {
+        setCountdown(duration);
+        setIsActive(true);
+    }, [duration]);
+
+    useEffect(() => {
+        if (isActive && countdown !== null) {
+            intervalRef.current = setInterval(() => {
+                setCountdown((prev) => {
+                    if (prev === null || prev <= 1) {
+                        setIsActive(false);
+                        onCompleteRef.current?.();
+                        return null;
+                    }
+                    return prev - 1;
+                });
+            }, 1000);
+        } else if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
+        }
+
+        return () => {
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current);
+                intervalRef.current = null;
+            }
+        };
+    }, [isActive, countdown]);
+
+    return {
+        countdown,
+        isActive,
+        start,
+        stop,
+        reset,
+    };
+}

--- a/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/useGetSeedWords.ts
+++ b/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/useGetSeedWords.ts
@@ -38,6 +38,7 @@ export function useGetSeedWords(args?: Arguments) {
     return {
         seedWords,
         getSeedWords,
+        setSeedWords,
         seedWordsFetched: hasFetched.current,
         seedWordsFetching,
     };

--- a/src/store/actions/walletStoreActions.ts
+++ b/src/store/actions/walletStoreActions.ts
@@ -175,6 +175,7 @@ export const handleSelectedTariAddressChange = (payload: TariAddressUpdatePayloa
     const { tari_address_base58, tari_address_emoji, tari_address_type } = payload;
     useWalletStore.setState({
         ...initialState,
+        is_wallet_importing: useWalletStore.getState().is_wallet_importing,
         tari_address_base58,
         tari_address_emoji,
         tari_address_type,


### PR DESCRIPTION
From #2520

Description
---
* Hide&Forget Seed words when imported seed, toggled off visibility, edited seed words and cancelled, after 30seconds of seed words visibility
* Optimistic UI for wallet import(close confirm dialog immediately(no loading state) and disable "edit" button until wallet is imported)
* Clean seed words form on each show
* Removed debug logs
* Display error when wrong pin passed while importing wallet